### PR TITLE
[Fix] Correct typo: feglet -> figlet in start-hypr.sh line 8

### DIFF
--- a/src/Scripts/hypr/start-hypr.sh
+++ b/src/Scripts/hypr/start-hypr.sh
@@ -5,7 +5,7 @@
 # Set exit on error
 set -euo pipefail
 
-# Check if feglet is installed and print banner
+# Check if figlet is installed and print banner
 is_installed_figlet() {
 	if ! command -v figlet >/dev/null 2>&1; then
 		clear


### PR DESCRIPTION
## Summary

Fixes the typo on line 8 of `src/Scripts/hypr/start-hypr.sh`: `feglet` → `figlet`.

Closes g5ostXa/hyprarch2#232