### PR TITLE
[Fix] Correct typo aboting -> aborting in lumineV2.sh

### DIFF
--- a/src/Scripts/lumineV2.sh
+++ b/src/Scripts/lumineV2.sh
@@ -55,7 +55,7 @@ main() {
 			exit 0
 		fi
 	else
-		echo -e "${RED}Failed to define BRIGHTNESSCTL_LEVEL, aboting...${RC}"
+		echo -e "${RED}Failed to define BRIGHTNESSCTL_LEVEL, aborting...${RC}"
 		exit 1
 	fi
 }


### PR DESCRIPTION
## Summary

Fixes typo in error message: `aboting` -> `aborting` on line 58 of `src/Scripts/lumineV2.sh`.

Closes g5ostXa/hyprarch2#236