### PR TITLE
docs(readme): fix two typos (Alot -> A lot, you -> your monitor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you like my project, feel free to  buy me a coffee, or simply give it a ⭐ !
 > [!WARNING]
 > Before you begin... 
 > - My dotfiles are meant to be installed via the installation process down below.
-> - Alot of it is very specific to me so if you're unfamiliar with [`hyprland`](https://hypr.land), I suggest you try [`mylinuxforwork's dotfiles`](https://github.com/mylinuxforwork/dotfiles) instead.
+> - A lot of it is very specific to me so if you're unfamiliar with [`hyprland`](https://hypr.land), I suggest you try [`mylinuxforwork's dotfiles`](https://github.com/mylinuxforwork/dotfiles) instead.
 > - This is NOT compatible with a different distro than upstream [`Arch`](https://archlinux.org).
 > - If installing on bare metal, do not forget to **backup your current installation** before proceeding.
 <br>
@@ -117,7 +117,7 @@ monitor=Virtual-1,2048x1080@60.00,0x0,1
 ```
 <br>
 
-Optionally, you can set you monitor(s) as env variables for extra compatibility. \
+Optionally, you can set your monitor(s) as env variables for extra compatibility. \
 Edit [`environment.conf`](/dotfiles/hypr/conf/environment.conf) and change the values of the following env variables to match your monitor(s):
 ```md
 # Monitor(s)


### PR DESCRIPTION
## Summary

Fixes the two single-character README.md typos the maintainer flagged across issues #240 and #241:

- `README.md:30`: `Alot` → `A lot` (#241)
- `README.md:120`: `you monitor(s)` → `your monitor(s)` (#240)

Both are one-character fixes targeting the same file, so I bundled them rather than open two separate PRs.

## Why this matters

The issues themselves are tiny but the README is the first thing a new user sees, and `Alot` is the kind of typo that lingers in a "Before you begin" warning section where attention is highest. Fixing both in a single PR keeps the maintainer's review queue at one item instead of two.

## Testing

- `git diff README.md` shows exactly two single-word substitutions, no other changes.
- `sed -n '30p;120p' README.md` after the change confirms both lines now read correctly.

Fixes #240
Fixes #241
