### PR TITLE
docs: fix missing closing quote in README.md install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If using a `VM`, uncomment the following in `~/hyprarch2/dotfiles/hypr/hyprland.
 
 Once you're all set, run [`install.sh`](src/install.sh) from `~/hyprarch2/src/`:
 ```bash
-$ cd "$HOME/hyprarch2/src && ./install.sh
+$ cd "$HOME/hyprarch2/src" && ./install.sh
 ```
 <br>
 


### PR DESCRIPTION
Fixed the missing closing quote in the install command on line 74:

- Before: cd "$HOME/hyprarch2/src && ./install.sh
- After: cd "$HOME/hyprarch2/src" && ./install.sh

Closes #246