### PR TITLE
fix: replace 'are define' with 'are defined' in monitor-toggle.sh

### DIFF
--- a/src/Scripts/hypr/monitor-toggle.sh
+++ b/src/Scripts/hypr/monitor-toggle.sh
@@ -3,7 +3,7 @@
 # // ==== monitor-toggle.sh ====
 
 # Script to toggle laptop monitor on and off
-# Monitor(s) are define in .config/hypr/conf/environment.lua
+# Monitor(s) are defined in .config/hypr/conf/environment.lua
 
 CURRENT_STATUS=$(hyprctl monitors -j | jq -r ".[] | select(.name==\"$PRIMARY_MONITOR\") | .dpmsStatus")
 


### PR DESCRIPTION
Fixes #264

Simple typo fix: `are define` → `are defined` in the comment on line 6 of `src/Scripts/hypr/monitor-toggle.sh`.